### PR TITLE
add-empty-folders

### DIFF
--- a/src/components/base/index.tsx
+++ b/src/components/base/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const index = () => {
+  return (
+    <div>
+      
+    </div>
+  )
+}
+
+export default index

--- a/src/components/modules/index.tsx
+++ b/src/components/modules/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const index = () => {
+  return (
+    <div>
+      
+    </div>
+  )
+}
+
+export default index

--- a/src/services/index.tsx
+++ b/src/services/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const index = () => {
+  return (
+    <div>
+      
+    </div>
+  )
+}
+
+export default index

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const index = () => {
+  return (
+    <div>
+      
+    </div>
+  )
+}
+
+export default index


### PR DESCRIPTION
## Qual o problema inicial?  
 Pastas vazias da estrutura inicial não estavam sendo exibidas.
## O que esse PR faz?  
 Adiciona arquivos iniciais nas pastas vazias.
## Como testar?
 Verificar inserção de novos arquivos.