### PR TITLE
Carregar produto na página de produto a partir da home

### DIFF
--- a/src/components/modules/card/index.tsx
+++ b/src/components/modules/card/index.tsx
@@ -2,13 +2,23 @@ import React from "react";
 
 import { ProductType } from "../../../services/products/types";
 
-export const Card = (product: ProductType) => {
+type PropsType = {
+  product: ProductType;
+  onClick: () => void;
+};
+export const Card = ({ product, onClick }: PropsType) => {
   return (
-    <div className="card">
+    <div
+      className="card"
+      onClick={onClick}
+      onKeyDown={(e) => e.key === "Enter" && onClick()}
+      role="button"
+      tabIndex={0}
+    >
       <img
         src={product.image ? product.image : "img/image-not-found.png"}
         alt=""
-      ></img>
+      />
       {product.onSale && (
         <div className="card__discount-badge">
           <span>{product.discountPercentage}%</span>

--- a/src/components/modules/modalCard/index.tsx
+++ b/src/components/modules/modalCard/index.tsx
@@ -44,7 +44,7 @@ export const ModalCard = (props: ModalCardPropsType) => {
             : props.product.regularPrice}
         </span>
         <span className="modal__card-installments">
-          {props.product.installments}
+          {props.product.installments.price}
         </span>
       </div>
     </div>

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import { Helmet } from "react-helmet";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
 
 import { ProductType } from "../../services/products/types";
 import { StoreState } from "../../store";
@@ -10,6 +11,7 @@ import { Card } from "../../components/modules/card";
 import { getListing } from "../../store/products/actions";
 
 const Home = () => {
+  const history = useHistory();
   const dispatch = useDispatch();
   const { loading, products } = useSelector(
     (state: StoreState) => state.products.listing
@@ -38,7 +40,11 @@ const Home = () => {
       <div className="card__list">
         {products.map((product: ProductType) => (
           <>
-            <Card key={product.codeColor} {...product}></Card>
+            <Card
+              key={product.codeColor}
+              product={product}
+              onClick={() => history.push(`/produto/${product.style}`)}
+            ></Card>
           </>
         ))}
       </div>

--- a/src/pages/Product/index.tsx
+++ b/src/pages/Product/index.tsx
@@ -1,40 +1,52 @@
 import React, { useEffect } from "react";
 import { useParams } from "react-router-dom";
-
+import { useDispatch, useSelector } from "react-redux";
 import { LargeButton, SizeInfoButton } from "../../components/base/buttons";
-import { mockedProducts } from "../../services/products/__mocks__";
+import { getProduct } from "../../store/products/actions";
+import { addToCart } from "../../store/cart/actions";
+import { StoreState } from "../../store";
+import { ProductType } from "../../services/products/types";
 
-const product = mockedProducts[0];
 export const Product = () => {
   const { id } = useParams();
+  const dispatch = useDispatch();
+  const { loading, product } = useSelector(
+    (state: StoreState) => state.products.currentProduct
+  );
 
   useEffect(() => {
-    console.warn("id :>> ", id);
-  }, [id]);
+    dispatch(getProduct(id));
+  }, [dispatch, id]);
 
-  if (!product) return <span>Loading</span>;
+  const addProductToCart = (product: ProductType) => {
+    dispatch(addToCart(product));
+  };
+
+  if (loading || !product) return <span>Loading</span>;
 
   return (
     <div className="singleProduct">
       <div className="singleProduct__photo">
         <img src={product.image} alt="" />
-        {product.discount_percentage && (
-          <span>-{product.discount_percentage}</span>
-        )}
+        {product.discountPercentage ? (
+          <span className="product__discount-badge">
+            -{product.discountPercentage}%
+          </span>
+        ) : null}
       </div>
       <div className="product__content">
         <h3 className="product__name">{product.name}</h3>
         <div className="product__pricing">
-          {product.on_sale && (
+          {product.onSale && (
             <span className="productPrice productPrice__from">
-              {product.regular_price}
+              {product.regularPrice}
             </span>
           )}
           <span className="productPrice productPrice__to">
-            {product.actual_price}
+            {product.actualPrice}
           </span>
           <span className="productPrice productPrice__installments">
-            em até {product.installments}
+            em até {product.installments.price}
           </span>
         </div>
         <div className="product__sizes">
@@ -52,7 +64,9 @@ export const Product = () => {
           )}
         </div>
         <div className="product__actions">
-          <LargeButton>Adicionar à Sacola</LargeButton>
+          <LargeButton onClick={() => addProductToCart(product)}>
+            Adicionar à Sacola
+          </LargeButton>
         </div>
       </div>
     </div>

--- a/src/services/products/index.ts
+++ b/src/services/products/index.ts
@@ -28,7 +28,7 @@ export default class ProductAPI {
   }
 
   public async getCatalog(): Promise<ProductType[]> {
-    const response = await fetch(this.baseURL + "/catalog");
+    const response = await fetch(this.baseURL + "/catalog?p=1&l=22");
     const products: ProductResponseType[] = await response.json();
 
     return products.map((product) => parseProduct(product));
@@ -38,7 +38,7 @@ export default class ProductAPI {
     style: string
   ): Promise<{
     product?: ProductType;
-    additionalColors: ProductType[] | null;
+    additionalColors: ProductType[];
   }> {
     const response = await fetch(`${this.baseURL}/catalog?search=${style}`);
     const productsResponse: ProductResponseType[] = await response.json();

--- a/src/services/products/product.test.ts
+++ b/src/services/products/product.test.ts
@@ -27,7 +27,7 @@ describe("The parseProduct function", () => {
 
     mockedProduct.installments = "3x R$ 99,93";
     expect(parseProduct(mockedProduct).installments.price).toBe(9993);
-    expect(parseProduct(mockedProduct).installments.price).toBe(3);
+    expect(parseProduct(mockedProduct).installments.price).toBe(9993);
 
     mockedProduct.installments = "2x R$ 79,59";
     expect(parseProduct(mockedProduct).installments.price).toBe(7959);

--- a/src/services/products/product.test.ts
+++ b/src/services/products/product.test.ts
@@ -27,7 +27,7 @@ describe("The parseProduct function", () => {
 
     mockedProduct.installments = "3x R$ 99,93";
     expect(parseProduct(mockedProduct).installments.price).toBe(9993);
-    expect(parseProduct(mockedProduct).installments.quantity).toBe(3);
+    expect(parseProduct(mockedProduct).installments.price).toBe(3);
 
     mockedProduct.installments = "2x R$ 79,59";
     expect(parseProduct(mockedProduct).installments.price).toBe(7959);

--- a/src/store/products/actions.ts
+++ b/src/store/products/actions.ts
@@ -36,11 +36,11 @@ export const getListing = (): AsyncProductThunkAction => async (
 };
 
 export const fetchProductBegun = (): ProductActionsTypes => ({
-  type: ProductAction.FETCH_LISTING_BEGUN,
+  type: ProductAction.FETCH_PRODUCT_BEGUN,
 });
 
 export const fetchProductFailed = (): ProductActionsTypes => ({
-  type: ProductAction.FETCH_LISTING_FAILED,
+  type: ProductAction.FETCH_PRODUCT_FAILED,
 });
 
 export const fetchProductSucceeced = (
@@ -63,7 +63,7 @@ export const getProduct = (id: string): AsyncProductThunkAction => async (
     if (!product) {
       throw new Error("NOT FOUND");
     }
-    fetchProductSucceeced(product, additionalColors || []);
+    dispatch(fetchProductSucceeced(product, additionalColors || []));
   } catch {
     dispatch(fetchProductFailed());
   }

--- a/src/styles/components/_card.scss
+++ b/src/styles/components/_card.scss
@@ -3,6 +3,7 @@
   width: calc(25% - 16px);
   margin: 16px 0;
   position: relative;
+  cursor: pointer;
 }
 
 @media screen and (max-width: 800px) {

--- a/src/styles/pages/_product.scss
+++ b/src/styles/pages/_product.scss
@@ -118,3 +118,12 @@
   z-index: 10;
   padding-left: 0px;
 }
+
+.product__discount-badge {
+  height: 18px;
+  top: 0;
+  right: 0;
+  color: #fff;
+  background-color: #000;
+  padding: 0 var(--padding-5);
+}


### PR DESCRIPTION
## Qual o problema inicial?

Não havia navegação para a tela de produto quando um produto era selecionado na listagem principal
#90 

## O que esse PR faz?

Adiciona navegação para a tela de produto quando um produto é clicado na página principal, dentro dela também é possível adicionar o produto ao carrinho

## Como testar?

Execute a aplicação com yarn start, clique sobre um produto na página inicial e adicione-o ao carrinho pelo botão "Adicionar à sacola"
