### PR TITLE
Corrige exibiçao de modal em mobile

### DIFF
--- a/src/components/base/modal/index.tsx
+++ b/src/components/base/modal/index.tsx
@@ -14,7 +14,13 @@ type PropsType = {
 
 export const Modal = ({ title, children, isOpen, close }: PropsType) => {
   useEffect(() => {
-    document.body.style.overflow = isOpen ? "hidden" : "inherit";
+    if (isOpen) {
+      document.body.style.overflow = "";
+      document.body.style.maxHeight = "100%";
+      return;
+    }
+    document.body.style.maxHeight = "";
+    document.body.style.overflow = "hidden";
   }, [isOpen]);
 
   return ReactDOM.createPortal(

--- a/src/styles/abstracts/_reset.scss
+++ b/src/styles/abstracts/_reset.scss
@@ -12,8 +12,7 @@ html {
   line-height: 1.15; /* 1 */
   -webkit-text-size-adjust: 100%; /* 2 */
   overflow-x: hidden;
-  min-height: 100%;
-  position: relative;
+  height: 100%;
 }
 
 /* Sections
@@ -26,7 +25,7 @@ html {
 body {
   margin: 0;
   background-color: #f9f9f9;
-  height: 100%;
+  position: relative;
 }
 
 /**

--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -5,7 +5,7 @@
   width: 100%;
   max-width: 375px;
   transform: translateX(100%);
-  height: 100vh;
+  height: 100%;
   background: #f9f9f9;
   transition: transform 0.2s ease;
   z-index: 2;


### PR DESCRIPTION
## Qual o problema inicial?
O header de navegadores mobile joga o footer do modal do carrinho, ocultando o valor até que o usuario realize o scroll

## O que esse PR faz?
Ao abrir o modal força o body a ter o tamanho visivel da viewport

## Como testar?